### PR TITLE
Fixed bug with source roots containing ancestor path elements

### DIFF
--- a/kotlin-maven-plugin-tools/src/main/kotlin/com/github/gantsign/maven/tools/plugin/extractor/kotlin/internal/SourceScanner.kt
+++ b/kotlin-maven-plugin-tools/src/main/kotlin/com/github/gantsign/maven/tools/plugin/extractor/kotlin/internal/SourceScanner.kt
@@ -169,7 +169,7 @@ internal class SourceScanner(
 
     private fun MavenProject.createScanRequest(): ProjectScanRequest {
         val compileSourceRoots: List<String> = compileSourceRoots!!
-        var sources = compileSourceRoots.map { Paths.get(it)!! }
+        val sources = compileSourceRoots.map { Paths.get(it)!! }.toMutableList()
 
         val generatedPlugin = basedir.toPath()
             .resolve(Paths.get("target", "generated-sources", "plugin"))
@@ -178,7 +178,7 @@ internal class SourceScanner(
         if (generatedPlugin.toString() !in compileSourceRoots &&
             Files.exists(generatedPlugin)
         ) {
-            sources += generatedPlugin
+            sources.add(generatedPlugin)
         }
 
         return ProjectScanRequest(this, sources)


### PR DESCRIPTION
Because `Path` implements `Iterable<Path>` Kotlin's `+=` operator was iterating over the path elements and adding them.