### PR TITLE
Fixed pom to inherit shade version

### DIFF
--- a/dokka-embeddable/pom.xml
+++ b/dokka-embeddable/pom.xml
@@ -94,7 +94,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
         <configuration>
           <artifactSet>
             <includes>


### PR DESCRIPTION
It's in the `pluginManagement` section of the root pom.