### PR TITLE
Fixed readExtendsExternalMojo test

### DIFF
--- a/kotlin-maven-plugin-tools/src/test/kotlin/com/github/gantsign/maven/tools/plugin/extractor/kotlin/DescriptorExtractorTest.kt
+++ b/kotlin-maven-plugin-tools/src/test/kotlin/com/github/gantsign/maven/tools/plugin/extractor/kotlin/DescriptorExtractorTest.kt
@@ -60,7 +60,7 @@ class DescriptorExtractorTest {
                 repositorySystem.createArtifact(
                     "org.apache.maven.plugins",
                     "maven-jar-plugin",
-                    "3.1.2",
+                    "3.2.0",
                     "jar"
                 )
             )


### PR DESCRIPTION
The version of `maven-jar-plugin` has changed.