### PR TITLE
Fixed Kotlin .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ trim_trailing_whitespaces = false
 indent_size=4
 continuation_indent_size=4
 charset = utf-8
-kotlin_imports_layout = ascii
+ij_kotlin_imports_layout = *
 
 # Files with a smaller indent
 [*.{java,xml}]


### PR DESCRIPTION
`kotlin_imports_layout` is deprecated.