### PR TITLE
Changed to not deploy the parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,15 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <inherited>false</inherited>
+        <configuration>
+          <!-- Since we flatten the POMs we don't need to deploy the parent -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
Not needed since we flatten the POMs.